### PR TITLE
feat: add variable corner radius slider for rectangles

### DIFF
--- a/packages/excalidraw/actions/types.ts
+++ b/packages/excalidraw/actions/types.ts
@@ -102,6 +102,7 @@ export type ActionName =
   | "goToCollaborator"
   | "addToLibrary"
   | "changeRoundness"
+  | "changeCornerRadius"
   | "alignTop"
   | "alignBottom"
   | "alignLeft"

--- a/packages/excalidraw/appState.ts
+++ b/packages/excalidraw/appState.ts
@@ -11,6 +11,7 @@ import {
   THEME,
   DEFAULT_GRID_STEP,
   isTestEnv,
+  DEFAULT_ADAPTIVE_RADIUS,
 } from "@excalidraw/common";
 
 import type { AppState, NormalizedZoomValue } from "./types";
@@ -38,6 +39,7 @@ export const getDefaultAppState = (): Omit<
     currentItemStartArrowhead: null,
     currentItemStrokeColor: DEFAULT_ELEMENT_PROPS.strokeColor,
     currentItemRoundness: isTestEnv() ? "sharp" : "round",
+    currentItemCornerRadius: DEFAULT_ADAPTIVE_RADIUS,
     currentItemArrowType: ARROW_TYPE.round,
     currentItemStrokeStyle: DEFAULT_ELEMENT_PROPS.strokeStyle,
     currentItemStrokeWidth: DEFAULT_ELEMENT_PROPS.strokeWidth,
@@ -161,6 +163,7 @@ const APP_STATE_STORAGE_CONF = (<
     export: false,
     server: false,
   },
+  currentItemCornerRadius: { browser: true, export: false, server: false },
   currentItemArrowType: {
     browser: true,
     export: false,

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -8682,6 +8682,7 @@ class App extends React.Component<AppProps, AppState> {
           type: isUsingAdaptiveRadius(elementType)
             ? ROUNDNESS.ADAPTIVE_RADIUS
             : ROUNDNESS.PROPORTIONAL_RADIUS,
+          value: this.state.currentItemCornerRadius,
         }
       : null;
   }

--- a/packages/excalidraw/components/CornerRadiusRange.tsx
+++ b/packages/excalidraw/components/CornerRadiusRange.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect } from "react";
+
+import { t } from "../i18n";
+
+import "./Range.scss";
+
+import type { AppClassProperties } from "../types";
+import { DEFAULT_ADAPTIVE_RADIUS } from "@excalidraw/common";
+
+export type CornerRadiusRangeProps = {
+  updateData: (value: number) => void;
+  app: AppClassProperties;
+  testId?: string;
+};
+
+export const CornerRadiusRange = ({
+  updateData,
+  app,
+  testId,
+}: CornerRadiusRangeProps) => {
+  const rangeRef = React.useRef<HTMLInputElement>(null);
+  const valueRef = React.useRef<HTMLDivElement>(null);
+  const selectedElements = app.scene.getSelectedElements(app.state);
+  let hasCommonCornerRadius = true;
+  const firstElement = selectedElements.at(0);
+  const leastCommonCornerRadius = selectedElements.reduce((acc, element) => {
+    const elementRadius = element.roundness?.value ?? DEFAULT_ADAPTIVE_RADIUS;
+    if (acc != null && acc !== elementRadius) {
+      hasCommonCornerRadius = false;
+    }
+    if (acc == null || acc > elementRadius) {
+      return elementRadius;
+    }
+    return acc;
+  }, firstElement?.roundness?.value ?? null);
+
+  const value =
+    leastCommonCornerRadius ?? app.state.currentItemCornerRadius;
+
+  useEffect(() => {
+    if (rangeRef.current && valueRef.current) {
+      const rangeElement = rangeRef.current;
+      const valueElement = valueRef.current;
+      const inputWidth = rangeElement.offsetWidth;
+      const thumbWidth = 15; // 15 is the width of the thumb
+      const position =
+        (value / 100) * (inputWidth - thumbWidth) + thumbWidth / 2;
+      valueElement.style.left = `${position}px`;
+      rangeElement.style.background = `linear-gradient(to right, var(--color-slider-track) 0%, var(--color-slider-track) ${value}%, var(--button-bg) ${value}%, var(--button-bg) 100%)`;
+    }
+  }, [value]);
+
+  return (
+    <label className="control-label">
+      {t("labels.cornerRadius")}
+      <div className="range-wrapper">
+        <input
+          style={{
+            ["--color-slider-track" as string]: hasCommonCornerRadius
+              ? undefined
+              : "var(--button-bg)",
+          }}
+          ref={rangeRef}
+          type="range"
+          min="0"
+          max="100"
+          step="4"
+          onChange={(event) => {
+            updateData(+event.target.value);
+          }}
+          value={value}
+          className="range-input"
+          data-testid={testId}
+        />
+        <div className="value-bubble" ref={valueRef}>
+          {value !== 0 ? value : null}
+        </div>
+        <div className="zero-label">0</div>
+      </div>
+    </label>
+  );
+};

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -36,6 +36,7 @@
     "edges": "Edges",
     "sharp": "Sharp",
     "round": "Round",
+    "cornerRadius": "Corner radius",
     "arrowheads": "Arrowheads",
     "arrowhead_none": "None",
     "arrowhead_arrow": "Arrow",

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -347,6 +347,7 @@ export interface AppState {
   currentItemEndArrowhead: Arrowhead | null;
   currentHoveredFontFamily: FontFamilyValues | null;
   currentItemRoundness: StrokeRoundness;
+  currentItemCornerRadius: number;
   currentItemArrowType: "sharp" | "round" | "elbow";
   viewBackgroundColor: string;
   scrollX: number;


### PR DESCRIPTION
Allow users to adjust rectangle corner radius with a slider (0-100px) instead of only having sharp/round toggle. The slider appears when "Round" edges are selected.

- Add currentItemCornerRadius to AppState (default 32px)
- Create CornerRadiusRange slider component
- Add actionChangeCornerRadius action
- Integrate slider below sharp/round toggle in properties panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)